### PR TITLE
add `Request.headers`

### DIFF
--- a/request.ts
+++ b/request.ts
@@ -18,6 +18,10 @@ export class Request {
     return this._serverRequest.url;
   }
 
+  get headers(): Headers {
+    return this._serverRequest.headers;
+  }
+
   constructor(serverRequest: ServerRequest) {
     this._serverRequest = serverRequest;
   }


### PR DESCRIPTION
I wrote a simple middleware but couldn't get the request's headers. Maybe should add a method to get headers.